### PR TITLE
Add Qt5/Qt6 dual compatibility for QGIS 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+    push:
+        branches: ["**"]
+    pull_request:
+        branches: [main]
+
+jobs:
+    pre-commit:
+        name: pre-commit
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: "3.13"
+            - uses: pre-commit/action@v3.0.1
+
+    bandit:
+        name: Bandit security scan
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: "3.13"
+            - name: Install Bandit
+              run: pip install bandit
+            - name: Run Bandit (matches plugins.qgis.org security scan)
+              run: bandit -r . -x ./tests
+
+    pyqt6-smoke:
+        name: PyQt6 import smoke
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                python-version: ["3.10", "3.11", "3.12", "3.13"]
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: ${{ matrix.python-version }}
+            - name: Install Qt6 runtime libs
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y libegl1 libgl1 libxkbcommon0 libdbus-1-3 libfontconfig1
+            - name: Install PyQt6 and pytest
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install PyQt6 pytest
+            - name: Run import smoke tests
+              run: pytest tests -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,10 @@ repos:
       rev: 0.9.1
       hooks:
           - id: nbstripout
+
+    - repo: https://github.com/PyCQA/bandit
+      rev: 1.9.4
+      hooks:
+          - id: bandit
+            args: ["-r", ".", "-x", "tests"]
+            pass_filenames: false

--- a/_samgeo_lib.py
+++ b/_samgeo_lib.py
@@ -148,7 +148,7 @@ def get_samgeo() -> ModuleType:
         if not _is_module_from_dir(imported, plugin_dir):
             _CACHED = imported
             return imported
-    except Exception:
+    except Exception:  # nosec B110
         pass
 
     imported = _import_samgeo_without_plugin_shadow(plugin_dir)

--- a/core/python_manager.py
+++ b/core/python_manager.py
@@ -9,7 +9,7 @@ Adapted from the GeoAI QGIS plugin's python_manager.py.
 import os
 import platform
 import shutil
-import subprocess
+import subprocess  # nosec B404
 import sys
 import tarfile
 import tempfile
@@ -40,12 +40,12 @@ PYTHON_VERSIONS = {
 }
 
 
-def _log(message: str, level=Qgis.Info):
+def _log(message: str, level=Qgis.MessageLevel.Info):
     """Log a message to the QGIS message log.
 
     Args:
         message: The message to log.
-        level: The log level (default: Qgis.Info).
+        level: The log level (default: Qgis.MessageLevel.Info).
     """
     QgsMessageLog.logMessage(message, "SamGeo", level=level)
 
@@ -236,13 +236,13 @@ def download_python_standalone(
         Tuple of (success, message).
     """
     if standalone_python_exists():
-        _log("Python standalone already exists", Qgis.Info)
+        _log("Python standalone already exists", Qgis.MessageLevel.Info)
         return True, "Python standalone already installed"
 
     url = get_download_url()
     python_version = get_python_full_version()
 
-    _log(f"Downloading Python {python_version} from: {url}", Qgis.Info)
+    _log(f"Downloading Python {python_version} from: {url}", Qgis.MessageLevel.Info)
 
     if progress_callback:
         progress_callback(0, f"Downloading Python {python_version}...")
@@ -271,7 +271,7 @@ def download_python_standalone(
                 )
             else:
                 error_msg = f"Download failed: {error_msg}"
-            _log(error_msg, Qgis.Critical)
+            _log(error_msg, Qgis.MessageLevel.Critical)
             return False, error_msg
 
         if cancel_check and cancel_check():
@@ -287,7 +287,10 @@ def download_python_standalone(
         with open(temp_path, "wb") as f:
             f.write(content.data())
 
-        _log(f"Download complete ({len(content)} bytes), extracting...", Qgis.Info)
+        _log(
+            f"Download complete ({len(content)} bytes), extracting...",
+            Qgis.MessageLevel.Info,
+        )
 
         if progress_callback:
             progress_callback(6, "Extracting Python...")
@@ -312,7 +315,7 @@ def download_python_standalone(
         if success:
             if progress_callback:
                 progress_callback(10, f"Python {python_version} installed")
-            _log("Python standalone installed successfully", Qgis.Success)
+            _log("Python standalone installed successfully", Qgis.MessageLevel.Success)
             return True, f"Python {python_version} installed successfully"
         else:
             return False, f"Verification failed: {verify_msg}"
@@ -321,7 +324,7 @@ def download_python_standalone(
         return False, "Download cancelled"
     except Exception as e:
         error_msg = f"Installation failed: {str(e)}"
-        _log(error_msg, Qgis.Critical)
+        _log(error_msg, Qgis.MessageLevel.Critical)
 
         if sys.platform == "win32":
             error_lower = str(e).lower()
@@ -333,7 +336,7 @@ def download_python_standalone(
                     "  2. Add an exclusion for: {}\n"
                     "  3. Try the installation again".format(STANDALONE_DIR)
                 )
-                _log(antivirus_help, Qgis.Warning)
+                _log(antivirus_help, Qgis.MessageLevel.Warning)
                 error_msg = f"{error_msg}\n\n{antivirus_help}"
 
         return False, error_msg
@@ -375,7 +378,7 @@ def verify_standalone_python() -> Tuple[bool, str]:
         env = _get_clean_env()
         subprocess_kwargs = _get_subprocess_kwargs()
 
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603
             [python_path, "-c", "import sys; print(sys.version)"],
             capture_output=True,
             text=True,
@@ -393,7 +396,7 @@ def verify_standalone_python() -> Tuple[bool, str]:
                 _log(
                     f"Python version mismatch: got {version_output}, "
                     f"expected {get_python_full_version()}",
-                    Qgis.Warning,
+                    Qgis.MessageLevel.Warning,
                 )
                 return (
                     False,
@@ -401,11 +404,14 @@ def verify_standalone_python() -> Tuple[bool, str]:
                     f"expected {get_python_full_version()}",
                 )
 
-            _log(f"Verified Python standalone: {version_output}", Qgis.Success)
+            _log(
+                f"Verified Python standalone: {version_output}",
+                Qgis.MessageLevel.Success,
+            )
             return True, f"Python {version_output} verified"
         else:
             error = result.stderr or "Unknown error"
-            _log(f"Python verification failed: {error}", Qgis.Warning)
+            _log(f"Python verification failed: {error}", Qgis.MessageLevel.Warning)
             return False, f"Verification failed: {error[:100]}"
 
     except subprocess.TimeoutExpired:
@@ -425,9 +431,9 @@ def remove_standalone_python() -> Tuple[bool, str]:
 
     try:
         shutil.rmtree(STANDALONE_DIR)
-        _log("Removed standalone Python installation", Qgis.Success)
+        _log("Removed standalone Python installation", Qgis.MessageLevel.Success)
         return True, "Standalone Python removed"
     except Exception as e:
         error_msg = f"Failed to remove: {str(e)}"
-        _log(error_msg, Qgis.Warning)
+        _log(error_msg, Qgis.MessageLevel.Warning)
         return False, error_msg

--- a/core/uv_manager.py
+++ b/core/uv_manager.py
@@ -11,7 +11,7 @@ import os
 import platform
 import shutil
 import stat
-import subprocess
+import subprocess  # nosec B404
 import sys
 import tarfile
 import tempfile
@@ -33,12 +33,12 @@ UV_DIR = os.path.join(CACHE_DIR, "uv")
 UV_VERSION = "0.10.6"
 
 
-def _log(message, level=Qgis.Info):
+def _log(message, level=Qgis.MessageLevel.Info):
     """Log a message to the QGIS message log.
 
     Args:
         message: The message to log.
-        level: The log level (Qgis.Info, Qgis.Warning, Qgis.Critical).
+        level: The log level (Qgis.MessageLevel.Info, Qgis.MessageLevel.Warning, Qgis.MessageLevel.Critical).
     """
     QgsMessageLog.logMessage(str(message), "SamGeo", level=level)
 
@@ -141,7 +141,7 @@ def download_uv(progress_callback=None, cancel_check=None):
                 )
             else:
                 error_msg = f"Download failed: {error_msg}"
-            _log(error_msg, Qgis.Critical)
+            _log(error_msg, Qgis.MessageLevel.Critical)
             return False, error_msg
 
         if cancel_check and cancel_check():
@@ -212,7 +212,7 @@ def download_uv(progress_callback=None, cancel_check=None):
         if success:
             if progress_callback:
                 progress_callback(100, f"uv {UV_VERSION} installed")
-            _log("uv installed successfully", Qgis.Success)
+            _log("uv installed successfully", Qgis.MessageLevel.Success)
             return True, f"uv {UV_VERSION} installed successfully"
         else:
             shutil.rmtree(UV_DIR, ignore_errors=True)
@@ -224,7 +224,7 @@ def download_uv(progress_callback=None, cancel_check=None):
     except Exception as e:
         shutil.rmtree(UV_DIR, ignore_errors=True)
         error_msg = f"uv installation failed: {str(e)}"
-        _log(error_msg, Qgis.Critical)
+        _log(error_msg, Qgis.MessageLevel.Critical)
         return False, error_msg
     finally:
         if os.path.exists(temp_path):
@@ -270,7 +270,7 @@ def verify_uv():
         if sys.platform == "win32":
             kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
 
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603
             [uv_path, "--version"],
             capture_output=True,
             text=True,
@@ -281,11 +281,11 @@ def verify_uv():
 
         if result.returncode == 0:
             version_output = result.stdout.strip()
-            _log(f"Verified uv: {version_output}", Qgis.Success)
+            _log(f"Verified uv: {version_output}", Qgis.MessageLevel.Success)
             return True, version_output
         else:
             error = result.stderr or "Unknown error"
-            _log(f"uv verification failed: {error}", Qgis.Warning)
+            _log(f"uv verification failed: {error}", Qgis.MessageLevel.Warning)
             return False, f"Verification failed: {error[:100]}"
 
     except subprocess.TimeoutExpired:
@@ -305,9 +305,9 @@ def remove_uv():
 
     try:
         shutil.rmtree(UV_DIR)
-        _log("Removed uv installation", Qgis.Success)
+        _log("Removed uv installation", Qgis.MessageLevel.Success)
         return True, "uv removed"
     except Exception as e:
         error_msg = f"Failed to remove uv: {str(e)}"
-        _log(error_msg, Qgis.Warning)
+        _log(error_msg, Qgis.MessageLevel.Warning)
         return False, error_msg

--- a/core/venv_manager.py
+++ b/core/venv_manager.py
@@ -12,7 +12,7 @@ import os
 import platform
 import re
 import shutil
-import subprocess
+import subprocess  # nosec B404
 import sys
 import tempfile
 import time
@@ -63,12 +63,12 @@ _MIN_COMPUTE_CAP_FOR_CU128 = 12.0
 _gpu_detect_cache = None  # type: Optional[Tuple[bool, dict]]
 
 
-def _log(message: str, level=Qgis.Info):
+def _log(message: str, level=Qgis.MessageLevel.Info):
     """Log a message to the QGIS message log.
 
     Args:
         message: The message to log.
-        level: The log level (default: Qgis.Info).
+        level: The log level (default: Qgis.MessageLevel.Info).
     """
     QgsMessageLog.logMessage(message, "SamGeo", level=level)
 
@@ -95,7 +95,7 @@ def _log_system_info():
     info_lines.append(f"  Cache directory: {CACHE_DIR}")
     info_lines.append("=" * 50)
     for line in info_lines:
-        _log(line, Qgis.Info)
+        _log(line, Qgis.MessageLevel.Info)
 
 
 # ---------------------------------------------------------------------------
@@ -118,7 +118,7 @@ def _write_cuda_flag(value: str):
         with open(CUDA_FLAG_FILE, "w", encoding="utf-8") as f:
             f.write(content)
     except (OSError, IOError) as e:
-        _log(f"Failed to write CUDA flag: {e}", Qgis.Warning)
+        _log(f"Failed to write CUDA flag: {e}", Qgis.MessageLevel.Warning)
 
 
 def _read_cuda_flag() -> Optional[str]:
@@ -189,7 +189,7 @@ def _write_deps_hash():
         with open(DEPS_HASH_FILE, "w", encoding="utf-8") as f:
             f.write(_compute_deps_hash())
     except (OSError, IOError) as e:
-        _log(f"Failed to write deps hash: {e}", Qgis.Warning)
+        _log(f"Failed to write deps hash: {e}", Qgis.MessageLevel.Warning)
 
 
 # ---------------------------------------------------------------------------
@@ -212,7 +212,7 @@ def detect_nvidia_gpu() -> Tuple[bool, dict]:
 
     try:
         subprocess_kwargs = _get_subprocess_kwargs()
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603 B607
             [
                 "nvidia-smi",
                 "--query-gpu=name,compute_cap,driver_version,memory.total",
@@ -261,16 +261,16 @@ def detect_nvidia_gpu() -> Tuple[bool, dict]:
 
             _log(
                 "NVIDIA GPU detected (best of {}): {}".format(len(lines), best_gpu),
-                Qgis.Info,
+                Qgis.MessageLevel.Info,
             )
             _gpu_detect_cache = (True, best_gpu)
             return _gpu_detect_cache
     except FileNotFoundError:
         pass
     except subprocess.TimeoutExpired:
-        _log("nvidia-smi timed out", Qgis.Warning)
+        _log("nvidia-smi timed out", Qgis.MessageLevel.Warning)
     except Exception as e:
-        _log(f"nvidia-smi check failed: {e}", Qgis.Warning)
+        _log(f"nvidia-smi check failed: {e}", Qgis.MessageLevel.Warning)
 
     _gpu_detect_cache = (False, {})
     return _gpu_detect_cache
@@ -301,7 +301,7 @@ def _select_cuda_index(gpu_info: dict) -> Optional[str]:
         except (ValueError, IndexError):
             _log(
                 f"Could not parse driver version: {driver_str}",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
 
     if needs_cu128:
@@ -322,7 +322,7 @@ def _select_cuda_index(gpu_info: dict) -> Optional[str]:
             _log(
                 "NVIDIA driver {} too old for {} (needs >= {}), "
                 "will use CPU instead".format(driver_str, cuda_index, required),
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
             return None
 
@@ -621,7 +621,7 @@ def _get_qgis_proxy_settings() -> Optional[str]:
             proxy_url += f":{port}"
         return proxy_url
     except Exception as e:
-        _log(f"Could not read QGIS proxy settings: {e}", Qgis.Warning)
+        _log(f"Could not read QGIS proxy settings: {e}", Qgis.MessageLevel.Warning)
         return None
 
 
@@ -634,7 +634,7 @@ def _get_pip_proxy_args() -> List[str]:
     proxy_url = _get_qgis_proxy_settings()
     if proxy_url:
         safe_url = proxy_url.split("@")[-1] if "@" in proxy_url else proxy_url
-        _log(f"Using QGIS proxy for pip: {safe_url}", Qgis.Info)
+        _log(f"Using QGIS proxy for pip: {safe_url}", Qgis.MessageLevel.Info)
         return ["--proxy", proxy_url]
     return []
 
@@ -740,17 +740,22 @@ def ensure_venv_packages_available() -> bool:
         True if packages were made available, False otherwise.
     """
     if not venv_exists():
-        _log("Venv does not exist, cannot load packages", Qgis.Warning)
+        _log("Venv does not exist, cannot load packages", Qgis.MessageLevel.Warning)
         return False
 
     site_packages = get_venv_site_packages()
     if not os.path.exists(site_packages):
-        _log(f"Venv site-packages not found: {site_packages}", Qgis.Warning)
+        _log(
+            f"Venv site-packages not found: {site_packages}", Qgis.MessageLevel.Warning
+        )
         return False
 
     if site_packages not in sys.path:
         sys.path.insert(0, site_packages)
-        _log(f"Added venv site-packages to sys.path: {site_packages}", Qgis.Info)
+        _log(
+            f"Added venv site-packages to sys.path: {site_packages}",
+            Qgis.MessageLevel.Info,
+        )
 
     # Fix PROJ database for the venv's pyproj / rasterio / pyogrio.
     _fix_proj_data(site_packages)
@@ -772,12 +777,12 @@ def ensure_venv_packages_available() -> bool:
                     "Reloaded typing_extensions {} -> {} from venv".format(
                         old_ver, new_te.__version__
                     ),
-                    Qgis.Info,
+                    Qgis.MessageLevel.Info,
                 )
         except Exception:
             _log(
                 "Failed to reload typing_extensions, torch may fail",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
 
     return True
@@ -800,9 +805,12 @@ def _add_windows_dll_directories(site_packages: str) -> None:
         if os.path.isdir(dll_dir):
             try:
                 os.add_dll_directory(dll_dir)
-                _log(f"Added DLL directory: {dll_dir}", Qgis.Info)
+                _log(f"Added DLL directory: {dll_dir}", Qgis.MessageLevel.Info)
             except OSError as exc:
-                _log(f"add_dll_directory({dll_dir}) failed: {exc}", Qgis.Warning)
+                _log(
+                    f"add_dll_directory({dll_dir}) failed: {exc}",
+                    Qgis.MessageLevel.Warning,
+                )
             if dll_dir not in path_parts:
                 path_parts.insert(0, dll_dir)
 
@@ -827,10 +835,10 @@ def _fix_proj_data(site_packages: str) -> None:
         if os.path.exists(proj_db):
             os.environ["PROJ_DATA"] = candidate
             os.environ["PROJ_LIB"] = candidate
-            _log(f"Set PROJ_DATA={candidate}", Qgis.Info)
+            _log(f"Set PROJ_DATA={candidate}", Qgis.MessageLevel.Info)
             break
     else:
-        _log("No venv proj.db found; PROJ_DATA unchanged", Qgis.Warning)
+        _log("No venv proj.db found; PROJ_DATA unchanged", Qgis.MessageLevel.Warning)
 
     # --- GDAL data ---
     gdal_candidates = [
@@ -841,7 +849,7 @@ def _fix_proj_data(site_packages: str) -> None:
     for candidate in gdal_candidates:
         if os.path.isdir(candidate):
             os.environ["GDAL_DATA"] = candidate
-            _log(f"Set GDAL_DATA={candidate}", Qgis.Info)
+            _log(f"Set GDAL_DATA={candidate}", Qgis.MessageLevel.Info)
             break
 
 
@@ -864,7 +872,7 @@ def _get_qgis_python() -> Optional[str]:
         python_path = os.path.join(sys.prefix, "python3.exe")
 
     if not os.path.exists(python_path):
-        _log("QGIS bundled Python not found at sys.prefix", Qgis.Warning)
+        _log("QGIS bundled Python not found at sys.prefix", Qgis.MessageLevel.Warning)
         return None
 
     try:
@@ -872,7 +880,7 @@ def _get_qgis_python() -> Optional[str]:
         env["PYTHONIOENCODING"] = "utf-8"
         subprocess_kwargs = _get_subprocess_kwargs()
 
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603
             [python_path, "-c", "import sys; print(sys.version)"],
             capture_output=True,
             text=True,
@@ -881,16 +889,18 @@ def _get_qgis_python() -> Optional[str]:
             **subprocess_kwargs,
         )
         if result.returncode == 0:
-            _log(f"QGIS Python verified: {result.stdout.strip()}", Qgis.Info)
+            _log(
+                f"QGIS Python verified: {result.stdout.strip()}", Qgis.MessageLevel.Info
+            )
             return python_path
         else:
             _log(
                 f"QGIS Python failed verification: {result.stderr}",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
             return None
     except Exception as e:
-        _log(f"QGIS Python verification error: {e}", Qgis.Warning)
+        _log(f"QGIS Python verification error: {e}", Qgis.MessageLevel.Warning)
         return None
 
 
@@ -910,7 +920,7 @@ def _get_system_python() -> str:
 
     if standalone_python_exists():
         python_path = get_standalone_python_path()
-        _log(f"Using standalone Python: {python_path}", Qgis.Info)
+        _log(f"Using standalone Python: {python_path}", Qgis.MessageLevel.Info)
         return python_path
 
     if sys.platform == "win32":
@@ -918,7 +928,7 @@ def _get_system_python() -> str:
         if qgis_python:
             _log(
                 "Standalone Python unavailable, using QGIS Python as fallback",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
             return qgis_python
 
@@ -942,9 +952,12 @@ def _cleanup_partial_venv(venv_dir: str):
     if os.path.exists(venv_dir):
         try:
             shutil.rmtree(venv_dir, ignore_errors=True)
-            _log(f"Cleaned up partial venv: {venv_dir}", Qgis.Info)
+            _log(f"Cleaned up partial venv: {venv_dir}", Qgis.MessageLevel.Info)
         except Exception:
-            _log(f"Could not clean up partial venv: {venv_dir}", Qgis.Warning)
+            _log(
+                f"Could not clean up partial venv: {venv_dir}",
+                Qgis.MessageLevel.Warning,
+            )
 
 
 def create_venv(
@@ -963,13 +976,13 @@ def create_venv(
     if venv_dir is None:
         venv_dir = VENV_DIR
 
-    _log(f"Creating virtual environment at: {venv_dir}", Qgis.Info)
+    _log(f"Creating virtual environment at: {venv_dir}", Qgis.MessageLevel.Info)
 
     if progress_callback:
         progress_callback(10, "Creating virtual environment...")
 
     system_python = _get_system_python()
-    _log(f"Using Python: {system_python}", Qgis.Info)
+    _log(f"Using Python: {system_python}", Qgis.MessageLevel.Info)
 
     from .uv_manager import get_uv_path, uv_exists
 
@@ -978,16 +991,16 @@ def create_venv(
     if use_uv:
         uv_path = get_uv_path()
         cmd = [uv_path, "venv", "--python", system_python, venv_dir]
-        _log(f"Creating venv with uv: {uv_path}", Qgis.Info)
+        _log(f"Creating venv with uv: {uv_path}", Qgis.MessageLevel.Info)
     else:
         cmd = [system_python, "-m", "venv", venv_dir]
-        _log("Creating venv with python -m venv", Qgis.Info)
+        _log("Creating venv with python -m venv", Qgis.MessageLevel.Info)
 
     try:
         env = _get_clean_env_for_venv()
         subprocess_kwargs = _get_subprocess_kwargs()
 
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603
             cmd,
             capture_output=True,
             text=True,
@@ -1001,7 +1014,7 @@ def create_venv(
                 "uv venv failed ({}), falling back to python -m venv".format(
                     result.stderr.strip() if result.stderr else result.returncode
                 ),
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
             from .uv_manager import remove_uv
 
@@ -1009,7 +1022,7 @@ def create_venv(
             use_uv = False
             _cleanup_partial_venv(venv_dir)
             cmd = [system_python, "-m", "venv", venv_dir]
-            result = subprocess.run(
+            result = subprocess.run(  # nosec B603
                 cmd,
                 capture_output=True,
                 text=True,
@@ -1019,19 +1032,19 @@ def create_venv(
             )
 
         if result.returncode == 0:
-            _log("Virtual environment created successfully", Qgis.Success)
+            _log("Virtual environment created successfully", Qgis.MessageLevel.Success)
 
             if not use_uv:
                 pip_path = get_venv_pip_path(venv_dir)
                 if not os.path.exists(pip_path):
                     _log(
                         "pip not found in venv, bootstrapping with ensurepip...",
-                        Qgis.Info,
+                        Qgis.MessageLevel.Info,
                     )
                     python_in_venv = get_venv_python_path(venv_dir)
                     ensurepip_cmd = [python_in_venv, "-m", "ensurepip", "--upgrade"]
                     try:
-                        ensurepip_result = subprocess.run(
+                        ensurepip_result = subprocess.run(  # nosec B603
                             ensurepip_cmd,
                             capture_output=True,
                             text=True,
@@ -1040,17 +1053,23 @@ def create_venv(
                             **subprocess_kwargs,
                         )
                         if ensurepip_result.returncode == 0:
-                            _log("pip bootstrapped via ensurepip", Qgis.Success)
+                            _log(
+                                "pip bootstrapped via ensurepip",
+                                Qgis.MessageLevel.Success,
+                            )
                         else:
                             err = ensurepip_result.stderr or ensurepip_result.stdout
-                            _log(f"ensurepip failed: {err[:200]}", Qgis.Warning)
+                            _log(
+                                f"ensurepip failed: {err[:200]}",
+                                Qgis.MessageLevel.Warning,
+                            )
                             _cleanup_partial_venv(venv_dir)
                             return (
                                 False,
                                 f"Failed to bootstrap pip: {err[:200]}",
                             )
                     except Exception as e:
-                        _log(f"ensurepip exception: {e}", Qgis.Warning)
+                        _log(f"ensurepip exception: {e}", Qgis.MessageLevel.Warning)
                         _cleanup_partial_venv(venv_dir)
                         return (
                             False,
@@ -1064,19 +1083,21 @@ def create_venv(
             error_msg = (
                 result.stderr or result.stdout or f"Return code {result.returncode}"
             )
-            _log(f"Failed to create venv: {error_msg}", Qgis.Critical)
+            _log(f"Failed to create venv: {error_msg}", Qgis.MessageLevel.Critical)
             _cleanup_partial_venv(venv_dir)
             return False, f"Failed to create venv: {error_msg[:200]}"
 
     except subprocess.TimeoutExpired:
-        _log("Virtual environment creation timed out", Qgis.Critical)
+        _log("Virtual environment creation timed out", Qgis.MessageLevel.Critical)
         _cleanup_partial_venv(venv_dir)
         return False, "Virtual environment creation timed out"
     except FileNotFoundError:
-        _log(f"Python executable not found: {system_python}", Qgis.Critical)
+        _log(
+            f"Python executable not found: {system_python}", Qgis.MessageLevel.Critical
+        )
         return False, f"Python not found: {system_python}"
     except Exception as e:
-        _log(f"Exception during venv creation: {str(e)}", Qgis.Critical)
+        _log(f"Exception during venv creation: {str(e)}", Qgis.MessageLevel.Critical)
         _cleanup_partial_venv(venv_dir)
         return False, f"Error: {str(e)[:200]}"
 
@@ -1172,17 +1193,17 @@ def _run_pip_install(
     except Exception:
         try:
             os.close(stdout_fd)
-        except Exception:
+        except Exception:  # nosec B110
             pass
         try:
             os.close(stderr_fd)
-        except Exception:
+        except Exception:  # nosec B110
             pass
         raise
 
     process = None
     try:
-        process = subprocess.Popen(
+        process = subprocess.Popen(  # nosec B603
             cmd,
             stdout=stdout_file,
             stderr=stderr_file,
@@ -1235,7 +1256,7 @@ def _run_pip_install(
                         if parsed:
                             last_download_status = parsed
                             break
-            except Exception:
+            except Exception:  # nosec B110
                 pass
 
             if elapsed >= 60:
@@ -1292,20 +1313,20 @@ def _run_pip_install(
         if stdout_file is not None:
             try:
                 stdout_file.close()
-            except Exception:
+            except Exception:  # nosec B110
                 pass
         if stderr_file is not None:
             try:
                 stderr_file.close()
-            except Exception:
+            except Exception:  # nosec B110
                 pass
         try:
             os.unlink(stdout_path)
-        except Exception:
+        except Exception:  # nosec B110
             pass
         try:
             os.unlink(stderr_path)
-        except Exception:
+        except Exception:  # nosec B110
             pass
 
 
@@ -1328,7 +1349,7 @@ def _is_cpu_torch_installed(
         True if CPU-only torch is installed.
     """
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603
             [python_path, "-c", "import torch; print(torch.version.cuda)"],
             capture_output=True,
             text=True,
@@ -1338,7 +1359,7 @@ def _is_cpu_torch_installed(
         )
         if result.returncode == 0:
             return result.stdout.strip() == "None"
-    except Exception:
+    except Exception:  # nosec B110
         pass
     return False
 
@@ -1361,7 +1382,7 @@ def _reinstall_cpu_torch(
     _use_uv = uv_exists()
     _uv_path = get_uv_path() if _use_uv else None
 
-    _log("Reinstalling CPU-only torch/torchvision...", Qgis.Warning)
+    _log("Reinstalling CPU-only torch/torchvision...", Qgis.MessageLevel.Warning)
     if progress_callback:
         progress_callback(96, "CUDA failed, reinstalling CPU torch...")
 
@@ -1386,7 +1407,7 @@ def _reinstall_cpu_torch(
                 "torch",
                 "torchvision",
             ]
-        subprocess.run(
+        subprocess.run(  # nosec B603
             uninstall_cmd,
             capture_output=True,
             text=True,
@@ -1395,7 +1416,7 @@ def _reinstall_cpu_torch(
             **subprocess_kwargs,
         )
     except Exception as e:
-        _log(f"torch uninstall error (continuing): {e}", Qgis.Warning)
+        _log(f"torch uninstall error (continuing): {e}", Qgis.MessageLevel.Warning)
 
     for pkg in ("torch>=2.0.0", "torchvision>=0.15.0"):
         try:
@@ -1426,7 +1447,7 @@ def _reinstall_cpu_torch(
                     + _get_pip_ssl_flags()
                     + [pkg]
                 )
-            result = subprocess.run(
+            result = subprocess.run(  # nosec B603
                 cmd,
                 capture_output=True,
                 text=True,
@@ -1435,12 +1456,15 @@ def _reinstall_cpu_torch(
                 **subprocess_kwargs,
             )
             if result.returncode == 0:
-                _log(f"Installed {pkg} (CPU)", Qgis.Success)
+                _log(f"Installed {pkg} (CPU)", Qgis.MessageLevel.Success)
             else:
                 err = result.stderr or result.stdout or ""
-                _log(f"Failed to install {pkg} (CPU): {err[:200]}", Qgis.Warning)
+                _log(
+                    f"Failed to install {pkg} (CPU): {err[:200]}",
+                    Qgis.MessageLevel.Warning,
+                )
         except Exception as e:
-            _log(f"Exception installing {pkg} (CPU): {e}", Qgis.Warning)
+            _log(f"Exception installing {pkg} (CPU): {e}", Qgis.MessageLevel.Warning)
 
     if progress_callback:
         progress_callback(98, "CPU torch installed, re-verifying...")
@@ -1472,7 +1496,7 @@ def _verify_cuda_in_venv(venv_dir: str) -> bool:
 
     try:
         for attempt in (1, 2):
-            result = subprocess.run(
+            result = subprocess.run(  # nosec B603
                 [python_path, "-c", cuda_test_code],
                 capture_output=True,
                 text=True,
@@ -1483,7 +1507,7 @@ def _verify_cuda_in_venv(venv_dir: str) -> bool:
             if result.returncode == 0 and "CUDA OK" in result.stdout:
                 _log(
                     "CUDA verification passed: {}".format(result.stdout.strip()[:400]),
-                    Qgis.Success,
+                    Qgis.MessageLevel.Success,
                 )
                 return True
 
@@ -1494,13 +1518,13 @@ def _verify_cuda_in_venv(venv_dir: str) -> bool:
                 "stdout: {}\nstderr: {}".format(
                     attempt, result.returncode, out[:400], err[:400]
                 ),
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
             if attempt == 1:
                 time.sleep(2)
         return False
     except Exception as e:
-        _log(f"CUDA verification exception: {e}", Qgis.Warning)
+        _log(f"CUDA verification exception: {e}", Qgis.MessageLevel.Warning)
         return False
 
 
@@ -1581,12 +1605,15 @@ def install_dependencies(
     use_uv = uv_exists()
     uv_path = get_uv_path() if use_uv else None
     if use_uv:
-        _log(f"Installing dependencies using uv: {uv_path}", Qgis.Info)
+        _log(f"Installing dependencies using uv: {uv_path}", Qgis.MessageLevel.Info)
     else:
         pip_path = get_venv_pip_path(venv_dir)
-        _log(f"Installing dependencies using pip: {pip_path}", Qgis.Info)
+        _log(f"Installing dependencies using pip: {pip_path}", Qgis.MessageLevel.Info)
     if cuda_enabled:
-        _log("CUDA mode enabled - will install GPU-accelerated PyTorch", Qgis.Info)
+        _log(
+            "CUDA mode enabled - will install GPU-accelerated PyTorch",
+            Qgis.MessageLevel.Info,
+        )
 
     _cuda_fell_back = False
     _driver_too_old = False
@@ -1624,13 +1651,13 @@ def install_dependencies(
             _log(
                 "CPU torch detected in venv, CUDA packages will use "
                 "--force-reinstall",
-                Qgis.Info,
+                Qgis.MessageLevel.Info,
             )
 
         num_cuda = len(cuda_packages)
         for ci, (package_name, version_spec) in enumerate(cuda_packages):
             if cancel_check and cancel_check():
-                _log("Installation cancelled by user", Qgis.Warning)
+                _log("Installation cancelled by user", Qgis.MessageLevel.Warning)
                 return False, "Installation cancelled"
 
             package_spec = f"{package_name}{version_spec}"
@@ -1649,7 +1676,7 @@ def install_dependencies(
                 )
             _log(
                 "[CUDA {}/{}] Installing {}...".format(ci + 1, num_cuda, package_spec),
-                Qgis.Info,
+                Qgis.MessageLevel.Info,
             )
 
             # Build install args
@@ -1683,7 +1710,7 @@ def install_dependencies(
                     "Driver too old for CUDA, installing CPU {} instead".format(
                         package_name
                     ),
-                    Qgis.Warning,
+                    Qgis.MessageLevel.Warning,
                 )
                 is_cuda_package = False
                 _driver_too_old = True
@@ -1697,14 +1724,14 @@ def install_dependencies(
                 )
                 _log(
                     "Using CUDA {} index for {}".format(cuda_index, package_name),
-                    Qgis.Info,
+                    Qgis.MessageLevel.Info,
                 )
 
             # Uninstall CPU torch before CUDA install
             if _force_cuda_reinstall and is_cuda_package:
                 _log(
                     "Uninstalling CPU {} before CUDA install".format(package_name),
-                    Qgis.Info,
+                    Qgis.MessageLevel.Info,
                 )
                 try:
                     if use_uv:
@@ -1725,7 +1752,7 @@ def install_dependencies(
                             "-y",
                             package_name,
                         ]
-                    subprocess.run(
+                    subprocess.run(  # nosec B603
                         uninstall_cmd,
                         capture_output=True,
                         text=True,
@@ -1736,7 +1763,7 @@ def install_dependencies(
                 except Exception as exc:
                     _log(
                         f"Failed to uninstall CPU {package_name}: {exc}",
-                        Qgis.Warning,
+                        Qgis.MessageLevel.Warning,
                     )
 
             if use_uv:
@@ -1774,7 +1801,7 @@ def install_dependencies(
                     if _is_hash_mismatch(error_output):
                         _log(
                             "Hash mismatch, retrying with --no-cache...",
-                            Qgis.Warning,
+                            Qgis.MessageLevel.Warning,
                         )
                         nocache_flag = "--no-cache" if use_uv else "--no-cache-dir"
                         result = _run_pip_install(
@@ -1797,7 +1824,7 @@ def install_dependencies(
                             _log(
                                 "Network error, retrying in 5s "
                                 "(attempt {}/2)...".format(attempt),
-                                Qgis.Warning,
+                                Qgis.MessageLevel.Warning,
                             )
                             if progress_callback:
                                 progress_callback(
@@ -1826,7 +1853,7 @@ def install_dependencies(
                 if result.returncode == 0:
                     _log(
                         "Successfully installed {}".format(package_spec),
-                        Qgis.Success,
+                        Qgis.MessageLevel.Success,
                     )
                     if progress_callback:
                         progress_callback(pkg_end, "{} installed".format(package_name))
@@ -1840,7 +1867,7 @@ def install_dependencies(
                         "Failed to install {}: {}".format(
                             package_spec, error_msg[:500]
                         ),
-                        Qgis.Critical,
+                        Qgis.MessageLevel.Critical,
                     )
                     install_failed = True
                     install_error_msg = error_msg
@@ -1849,14 +1876,14 @@ def install_dependencies(
             except subprocess.TimeoutExpired:
                 _log(
                     "Installation of {} timed out".format(package_spec),
-                    Qgis.Critical,
+                    Qgis.MessageLevel.Critical,
                 )
                 install_failed = True
                 install_error_msg = "Installation of {} timed out".format(package_name)
             except Exception as e:
                 _log(
                     "Exception installing {}: {}".format(package_spec, e),
-                    Qgis.Critical,
+                    Qgis.MessageLevel.Critical,
                 )
                 install_failed = True
                 install_error_msg = "Error installing {}: {}".format(
@@ -1869,7 +1896,7 @@ def install_dependencies(
                     "CUDA install of {} failed, falling back to CPU...".format(
                         package_name
                     ),
-                    Qgis.Warning,
+                    Qgis.MessageLevel.Warning,
                 )
                 if progress_callback:
                     progress_callback(
@@ -1913,7 +1940,7 @@ def install_dependencies(
                     if cpu_result.returncode == 0:
                         _log(
                             "Successfully installed {} (CPU)".format(package_spec),
-                            Qgis.Success,
+                            Qgis.MessageLevel.Success,
                         )
                         if progress_callback:
                             progress_callback(
@@ -1945,7 +1972,7 @@ def install_dependencies(
             if install_failed:
                 _log(
                     "pip error output: {}".format(install_error_msg[:500]),
-                    Qgis.Critical,
+                    Qgis.MessageLevel.Critical,
                 )
                 if _is_ssl_error(install_error_msg):
                     return (
@@ -1989,7 +2016,7 @@ def install_dependencies(
     # -- Phase B: Batch install remaining packages ----------------------------
     if batch_packages:
         if cancel_check and cancel_check():
-            _log("Installation cancelled by user", Qgis.Warning)
+            _log("Installation cancelled by user", Qgis.MessageLevel.Warning)
             return False, "Installation cancelled"
 
         batch_specs = ["{}{}".format(name, ver) for name, ver in batch_packages]
@@ -1997,7 +2024,7 @@ def install_dependencies(
             "Installing {} packages in batch: {}".format(
                 len(batch_specs), ", ".join(batch_specs)
             ),
-            Qgis.Info,
+            Qgis.MessageLevel.Info,
         )
         if progress_callback:
             progress_callback(batch_start, "Installing dependencies...")
@@ -2050,7 +2077,7 @@ def install_dependencies(
                 if _is_hash_mismatch(error_output):
                     _log(
                         "Hash mismatch, retrying batch with --no-cache...",
-                        Qgis.Warning,
+                        Qgis.MessageLevel.Warning,
                     )
                     nocache_flag = "--no-cache" if use_uv else "--no-cache-dir"
                     result = _run_pip_install(
@@ -2073,7 +2100,7 @@ def install_dependencies(
                         _log(
                             "Network error, retrying batch in 5s "
                             "(attempt {}/2)...".format(attempt),
-                            Qgis.Warning,
+                            Qgis.MessageLevel.Warning,
                         )
                         if progress_callback:
                             progress_callback(
@@ -2105,7 +2132,7 @@ def install_dependencies(
                     _log(
                         "Optional package {} failed in batch; "
                         "retrying without it...".format(failed_pkg),
-                        Qgis.Warning,
+                        Qgis.MessageLevel.Warning,
                     )
                     retry_specs = [
                         s for s in batch_specs if not s.startswith(failed_pkg)
@@ -2152,7 +2179,10 @@ def install_dependencies(
                         )
 
             if result.returncode == 0:
-                _log("Batch install succeeded for all packages", Qgis.Success)
+                _log(
+                    "Batch install succeeded for all packages",
+                    Qgis.MessageLevel.Success,
+                )
                 if progress_callback:
                     progress_callback(batch_end, "All dependencies installed")
             else:
@@ -2162,7 +2192,7 @@ def install_dependencies(
                 )
                 _log(
                     "Batch install failed: {}".format(error_output[:500]),
-                    Qgis.Critical,
+                    Qgis.MessageLevel.Critical,
                 )
                 if _is_ssl_error(error_output):
                     return (
@@ -2201,19 +2231,22 @@ def install_dependencies(
                 )
 
         except subprocess.TimeoutExpired:
-            _log("Batch install timed out", Qgis.Critical)
+            _log("Batch install timed out", Qgis.MessageLevel.Critical)
             return False, "Dependency installation timed out"
         except Exception as e:
-            _log("Exception during batch install: {}".format(e), Qgis.Critical)
+            _log(
+                "Exception during batch install: {}".format(e),
+                Qgis.MessageLevel.Critical,
+            )
             return False, "Error installing dependencies: {}".format(str(e)[:200])
 
     if progress_callback:
         progress_callback(100, "All dependencies installed")
 
-    _log("=" * 50, Qgis.Success)
-    _log("All dependencies installed successfully!", Qgis.Success)
-    _log(f"Virtual environment: {venv_dir}", Qgis.Success)
-    _log("=" * 50, Qgis.Success)
+    _log("=" * 50, Qgis.MessageLevel.Success)
+    _log("All dependencies installed successfully!", Qgis.MessageLevel.Success)
+    _log(f"Virtual environment: {venv_dir}", Qgis.MessageLevel.Success)
+    _log("=" * 50, Qgis.MessageLevel.Success)
 
     if _driver_too_old:
         return True, "All dependencies installed successfully [DRIVER_TOO_OLD]"
@@ -2323,7 +2356,7 @@ def verify_venv(
         )
 
         try:
-            result = subprocess.run(
+            result = subprocess.run(  # nosec B603
                 cmd,
                 capture_output=True,
                 text=True,
@@ -2340,13 +2373,13 @@ def verify_venv(
                     "Package {} verification failed: {}".format(
                         package_name, error_detail
                     ),
-                    Qgis.Warning,
+                    Qgis.MessageLevel.Warning,
                 )
                 if is_optional:
                     _log(
                         "Package {} verification failed but is optional on this "
                         "platform; continuing.".format(package_name),
-                        Qgis.Warning,
+                        Qgis.MessageLevel.Warning,
                     )
                     optional_failures.append(package_name)
                     continue
@@ -2359,10 +2392,10 @@ def verify_venv(
                 "Verification of {} timed out ({}s), retrying...".format(
                     package_name, pkg_timeout
                 ),
-                Qgis.Info,
+                Qgis.MessageLevel.Info,
             )
             try:
-                result = subprocess.run(
+                result = subprocess.run(  # nosec B603
                     cmd,
                     capture_output=True,
                     text=True,
@@ -2396,7 +2429,7 @@ def verify_venv(
         except Exception as e:
             _log(
                 "Failed to verify {}: {}".format(package_name, str(e)),
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
             return False, "Verification error: {}".format(package_name)
 
@@ -2409,7 +2442,7 @@ def verify_venv(
             "Virtual environment verified with optional package failures: {}".format(
                 ", ".join(unique_optional)
             ),
-            Qgis.Warning,
+            Qgis.MessageLevel.Warning,
         )
         return (
             True,
@@ -2418,7 +2451,7 @@ def verify_venv(
             ),
         )
 
-    _log("Virtual environment verified successfully", Qgis.Success)
+    _log("Virtual environment verified successfully", Qgis.MessageLevel.Success)
     return True, "Virtual environment ready"
 
 
@@ -2450,15 +2483,15 @@ def cleanup_old_venv_directories() -> List[str]:
                 if os.path.isdir(old_path):
                     try:
                         shutil.rmtree(old_path)
-                        _log(f"Cleaned up old venv: {old_path}", Qgis.Info)
+                        _log(f"Cleaned up old venv: {old_path}", Qgis.MessageLevel.Info)
                         removed.append(old_path)
                     except Exception as e:
                         _log(
                             f"Failed to remove old venv {old_path}: {e}",
-                            Qgis.Warning,
+                            Qgis.MessageLevel.Warning,
                         )
     except Exception as e:
-        _log(f"Error scanning for old venvs: {e}", Qgis.Warning)
+        _log(f"Error scanning for old venvs: {e}", Qgis.MessageLevel.Warning)
 
     return removed
 
@@ -2498,13 +2531,13 @@ def _quick_check_packages(venv_dir: str = None) -> Tuple[bool, str]:
         if not os.path.exists(pkg_dir):
             _log(
                 "Quick check: {} not found at {}".format(package_name, pkg_dir),
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
             return False, "Package {} not found".format(package_name)
 
     _log(
         "Quick check: all packages found in {}".format(site_packages),
-        Qgis.Info,
+        Qgis.MessageLevel.Info,
     )
     return True, "All packages found"
 
@@ -2524,11 +2557,11 @@ def get_venv_status() -> Tuple[bool, str]:
         if sys.platform == "win32" and venv_exists():
             pass  # venv was created with QGIS Python fallback
         else:
-            _log("get_venv_status: standalone Python not found", Qgis.Info)
+            _log("get_venv_status: standalone Python not found", Qgis.MessageLevel.Info)
             return False, "Dependencies not installed"
 
     if not venv_exists():
-        _log(f"get_venv_status: venv not found at {VENV_DIR}", Qgis.Info)
+        _log(f"get_venv_status: venv not found at {VENV_DIR}", Qgis.MessageLevel.Info)
         return False, "Virtual environment not configured"
 
     is_present, msg = _quick_check_packages()
@@ -2539,20 +2572,20 @@ def get_venv_status() -> Tuple[bool, str]:
             _log(
                 "get_venv_status: deps hash mismatch "
                 "(stored={}, current={})".format(stored_hash, current_hash),
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
             return False, "Dependencies need updating"
         if stored_hash is None:
             _log(
                 "get_venv_status: no deps hash file, writing current hash",
-                Qgis.Info,
+                Qgis.MessageLevel.Info,
             )
             _write_deps_hash()
         python_version = get_python_full_version()
-        _log("get_venv_status: ready (quick check passed)", Qgis.Success)
+        _log("get_venv_status: ready (quick check passed)", Qgis.MessageLevel.Success)
         return True, "Ready (Python {})".format(python_version)
     else:
-        _log(f"get_venv_status: quick check failed: {msg}", Qgis.Warning)
+        _log(f"get_venv_status: quick check failed: {msg}", Qgis.MessageLevel.Warning)
         return False, "Virtual environment incomplete: {}".format(msg)
 
 
@@ -2573,10 +2606,10 @@ def remove_venv(venv_dir: str = None) -> Tuple[bool, str]:
 
     try:
         shutil.rmtree(venv_dir)
-        _log(f"Removed virtual environment: {venv_dir}", Qgis.Success)
+        _log(f"Removed virtual environment: {venv_dir}", Qgis.MessageLevel.Success)
         return True, "Virtual environment removed"
     except Exception as e:
-        _log(f"Failed to remove venv: {e}", Qgis.Warning)
+        _log(f"Failed to remove venv: {e}", Qgis.MessageLevel.Warning)
         return False, f"Failed to remove venv: {str(e)[:200]}"
 
 
@@ -2636,12 +2669,16 @@ def create_venv_and_install(
 
     removed_venvs = cleanup_old_venv_directories()
     if removed_venvs:
-        _log(f"Removed {len(removed_venvs)} old venv directories", Qgis.Info)
+        _log(
+            f"Removed {len(removed_venvs)} old venv directories", Qgis.MessageLevel.Info
+        )
 
     # Step 1: Download Python standalone (0-10%)
     if not standalone_python_exists():
         python_version = get_python_full_version()
-        _log(f"Downloading Python {python_version} standalone...", Qgis.Info)
+        _log(
+            f"Downloading Python {python_version} standalone...", Qgis.MessageLevel.Info
+        )
 
         def python_progress(percent, msg):
             if progress_callback:
@@ -2659,7 +2696,7 @@ def create_venv_and_install(
                     _log(
                         "Standalone Python download failed, "
                         "falling back to QGIS Python: {}".format(msg),
-                        Qgis.Warning,
+                        Qgis.MessageLevel.Warning,
                     )
                     if progress_callback:
                         progress_callback(10, "Using QGIS Python (fallback)...")
@@ -2671,13 +2708,13 @@ def create_venv_and_install(
         if cancel_check and cancel_check():
             return False, "Installation cancelled"
     else:
-        _log("Python standalone already installed", Qgis.Info)
+        _log("Python standalone already installed", Qgis.MessageLevel.Info)
         if progress_callback:
             progress_callback(10, "Python standalone ready")
 
     # Step 1b: Download uv package installer (10-13%)
     if not _uv_exists():
-        _log("Downloading uv package installer...", Qgis.Info)
+        _log("Downloading uv package installer...", Qgis.MessageLevel.Info)
         if progress_callback:
             progress_callback(10, "Downloading uv package installer...")
 
@@ -2692,21 +2729,21 @@ def create_venv_and_install(
         if not uv_success:
             _log(
                 "uv download failed (will use pip instead): {}".format(uv_msg),
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
         else:
-            _log("uv package installer ready", Qgis.Info)
+            _log("uv package installer ready", Qgis.MessageLevel.Info)
 
         if cancel_check and cancel_check():
             return False, "Installation cancelled"
     else:
-        _log("uv package installer already installed", Qgis.Info)
+        _log("uv package installer already installed", Qgis.MessageLevel.Info)
         if progress_callback:
             progress_callback(13, "uv package installer ready")
 
     # Step 2: Create venv (13-18%)
     if venv_exists():
-        _log("Virtual environment already exists", Qgis.Info)
+        _log("Virtual environment already exists", Qgis.MessageLevel.Info)
         if progress_callback:
             progress_callback(18, "Virtual environment ready")
     else:
@@ -2748,7 +2785,7 @@ def create_venv_and_install(
             _log(
                 "Verification failed with CUDA torch, "
                 "falling back to CPU: {}".format(verify_msg),
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
             _reinstall_cpu_torch(VENV_DIR, progress_callback=progress_callback)
             is_valid, verify_msg = verify_venv(progress_callback=verify_progress)
@@ -2765,7 +2802,7 @@ def create_venv_and_install(
         elif not cuda_works and not _cuda_fell_back:
             _log(
                 "CUDA smoke test failed after install.",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
             _cuda_smoke_failed = True
 

--- a/deps_install_dialog.py
+++ b/deps_install_dialog.py
@@ -42,7 +42,9 @@ class DepsInstallDockWidget(QDockWidget):
         """
         super().__init__("SamGeo - Setup", parent)
         self.setObjectName("SamGeoDepsInstallDock")
-        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
 
         container = QWidget()
         layout = QVBoxLayout(container)
@@ -221,7 +223,7 @@ class DepsInstallDockWidget(QDockWidget):
             from .core.venv_manager import remove_venv
 
             remove_venv()
-        except Exception:
+        except Exception:  # nosec B110
             pass
         self.reinstall_button.hide()
         self.install_requested.emit()

--- a/map_tools.py
+++ b/map_tools.py
@@ -29,7 +29,7 @@ class PointPromptTool(QgsMapTool):
         self.markers = []
 
         # Set cursor
-        self.setCursor(Qt.CrossCursor)
+        self.setCursor(Qt.CursorShape.CrossCursor)
 
     def set_foreground(self, foreground):
         """Set whether we're adding foreground or background points."""
@@ -41,7 +41,7 @@ class PointPromptTool(QgsMapTool):
 
     def canvasReleaseEvent(self, event):
         """Handle mouse release event - add a point."""
-        if event.button() == Qt.LeftButton:
+        if event.button() == Qt.MouseButton.LeftButton:
             point = self.toMapCoordinates(event.pos())
 
             # Add visual marker
@@ -65,7 +65,7 @@ class PointPromptTool(QgsMapTool):
             else:
                 self.plugin.add_point(point, self.is_foreground)
 
-        elif event.button() == Qt.RightButton:
+        elif event.button() == Qt.MouseButton.RightButton:
             # Right-click to finish
             self.deactivate()
             if self.batch_mode:
@@ -102,7 +102,9 @@ class BoxPromptTool(QgsMapTool):
         self.plugin = plugin
 
         # Rubber band for visual feedback
-        self.rubber_band = QgsRubberBand(canvas, QgsWkbTypes.PolygonGeometry)
+        self.rubber_band = QgsRubberBand(
+            canvas, QgsWkbTypes.GeometryType.PolygonGeometry
+        )
         self.rubber_band.setColor(QColor(0, 120, 255, 100))
         self.rubber_band.setStrokeColor(QColor(0, 120, 255))
         self.rubber_band.setWidth(2)
@@ -111,14 +113,14 @@ class BoxPromptTool(QgsMapTool):
         self.is_drawing = False
 
         # Set cursor
-        self.setCursor(Qt.CrossCursor)
+        self.setCursor(Qt.CursorShape.CrossCursor)
 
     def canvasPressEvent(self, event):
         """Handle mouse press event - start drawing."""
-        if event.button() == Qt.LeftButton:
+        if event.button() == Qt.MouseButton.LeftButton:
             self.start_point = self.toMapCoordinates(event.pos())
             self.is_drawing = True
-            self.rubber_band.reset(QgsWkbTypes.PolygonGeometry)
+            self.rubber_band.reset(QgsWkbTypes.GeometryType.PolygonGeometry)
 
     def canvasMoveEvent(self, event):
         """Handle mouse move event - update rubber band."""
@@ -128,7 +130,7 @@ class BoxPromptTool(QgsMapTool):
 
     def canvasReleaseEvent(self, event):
         """Handle mouse release event - finish drawing."""
-        if event.button() == Qt.LeftButton and self.is_drawing:
+        if event.button() == Qt.MouseButton.LeftButton and self.is_drawing:
             end_point = self.toMapCoordinates(event.pos())
             self.is_drawing = False
 
@@ -145,16 +147,16 @@ class BoxPromptTool(QgsMapTool):
             self.deactivate()
             self.plugin.draw_box_btn.setChecked(False)
 
-        elif event.button() == Qt.RightButton:
+        elif event.button() == Qt.MouseButton.RightButton:
             # Right-click to cancel
             self.is_drawing = False
-            self.rubber_band.reset(QgsWkbTypes.PolygonGeometry)
+            self.rubber_band.reset(QgsWkbTypes.GeometryType.PolygonGeometry)
             self.deactivate()
             self.plugin.draw_box_btn.setChecked(False)
 
     def update_rubber_band(self, start_point, end_point):
         """Update the rubber band rectangle."""
-        self.rubber_band.reset(QgsWkbTypes.PolygonGeometry)
+        self.rubber_band.reset(QgsWkbTypes.GeometryType.PolygonGeometry)
 
         # Create rectangle points
         self.rubber_band.addPoint(QgsPointXY(start_point.x(), start_point.y()), False)
@@ -164,7 +166,7 @@ class BoxPromptTool(QgsMapTool):
 
     def clear_rubber_band(self):
         """Clear the rubber band."""
-        self.rubber_band.reset(QgsWkbTypes.PolygonGeometry)
+        self.rubber_band.reset(QgsWkbTypes.GeometryType.PolygonGeometry)
 
     def deactivate(self):
         """Deactivate the tool."""

--- a/metadata.txt
+++ b/metadata.txt
@@ -1,8 +1,9 @@
 [general]
 name=SamGeo
 qgisMinimumVersion=3.22
+qgisMaximumVersion=4.99
 description=Segment remote sensing images using SAM (Segment Anything Model) with text, point, and box prompts.
-version=1.3.0
+version=1.4.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 about=A QGIS plugin for remote sensing image segmentation powered by Meta's Segment Anything Model (SAM).
@@ -21,6 +22,7 @@ icon=icons/icon.png
 experimental=True
 deprecated=False
 changelog=
+    1.4.0 - Qt5/Qt6 dual compatibility for QGIS 4.0 (qualify enums, replace exec_())
     1.3.0 - Add one-click installation of dependencies
     1.1.0 - Fix plugin name import
     1.0.0 - Initial release

--- a/samgeo_plugin.py
+++ b/samgeo_plugin.py
@@ -225,7 +225,7 @@ class SamGeoPlugin:
                 ensure_venv_packages_available()
                 self._deps_available = True
                 return True
-        except Exception:
+        except Exception:  # nosec B110
             pass
 
         self._show_deps_install_dock()
@@ -244,7 +244,7 @@ class SamGeoPlugin:
         self._deps_dock.install_requested.connect(self._on_install_requested)
         self._deps_dock.cancel_requested.connect(self._on_cancel_install)
 
-        self.iface.addDockWidget(Qt.RightDockWidgetArea, self._deps_dock)
+        self.iface.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, self._deps_dock)
         self._deps_dock.show()
         self._deps_dock.raise_()
 
@@ -298,7 +298,7 @@ class SamGeoPlugin:
                 from .core.venv_manager import ensure_venv_packages_available
 
                 ensure_venv_packages_available()
-            except Exception:
+            except Exception:  # nosec B110
                 pass
 
             # Close the deps dock and open the main plugin panel
@@ -310,7 +310,9 @@ class SamGeoPlugin:
             # Now show the main plugin dock
             if self.dock_widget is None:
                 self.dock_widget = self.create_dock_widget()
-                self.iface.addDockWidget(Qt.RightDockWidgetArea, self.dock_widget)
+                self.iface.addDockWidget(
+                    Qt.DockWidgetArea.RightDockWidgetArea, self.dock_widget
+                )
             else:
                 self.dock_widget.show()
 
@@ -331,14 +333,18 @@ class SamGeoPlugin:
 
         if self.dock_widget is None:
             self.dock_widget = self.create_dock_widget()
-            self.iface.addDockWidget(Qt.RightDockWidgetArea, self.dock_widget)
+            self.iface.addDockWidget(
+                Qt.DockWidgetArea.RightDockWidgetArea, self.dock_widget
+            )
         else:
             self.dock_widget.show()
 
     def create_dock_widget(self):
         """Create the dock widget with all controls."""
         dock = QDockWidget("SamGeo Segmentation", self.iface.mainWindow())
-        dock.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        dock.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
 
         # Main widget
         main_widget = QWidget()
@@ -807,7 +813,7 @@ class SamGeoPlugin:
         for layer in layers:
             if isinstance(layer, QgsVectorLayer):
                 # Only include point layers
-                if layer.geometryType() == QgsWkbTypes.PointGeometry:
+                if layer.geometryType() == QgsWkbTypes.GeometryType.PointGeometry:
                     self.vector_layer_combo.addItem(layer.name(), layer.id())
 
     def browse_vector_file(self):
@@ -1118,7 +1124,9 @@ class SamGeoPlugin:
             # Update list widget
             label_text = "FG" if foreground else "BG"
             item = QListWidgetItem(f"{label_text}: ({px:.1f}, {py:.1f})")
-            item.setForeground(Qt.green if foreground else Qt.red)
+            item.setForeground(
+                Qt.GlobalColor.green if foreground else Qt.GlobalColor.red
+            )
             self.points_list.addItem(item)
 
     def clear_points(self):
@@ -1163,7 +1171,7 @@ class SamGeoPlugin:
             item = QListWidgetItem(
                 f"Point {len(self.batch_point_coords)}: ({px:.1f}, {py:.1f})"
             )
-            item.setForeground(Qt.green)
+            item.setForeground(Qt.GlobalColor.green)
             self.batch_points_list.addItem(item)
 
             # Update count label
@@ -1599,7 +1607,9 @@ class SamGeoPlugin:
             self.log_message(f"Auto-saved masks to: {output_path}")
 
         except Exception as e:
-            self.log_message(f"Auto-show failed: {str(e)}", level=Qgis.Warning)
+            self.log_message(
+                f"Auto-show failed: {str(e)}", level=Qgis.MessageLevel.Warning
+            )
             self.show_error(f"Auto-show failed: {str(e)}")
 
     def save_masks(self):
@@ -1691,9 +1701,9 @@ class SamGeoPlugin:
     def show_error(self, message):
         """Show an error message."""
         QMessageBox.critical(self.iface.mainWindow(), "SamGeo Error", message)
-        self.log_message(message, level=Qgis.Critical)
+        self.log_message(message, level=Qgis.MessageLevel.Critical)
 
-    def log_message(self, message, level=Qgis.Info):
+    def log_message(self, message, level=Qgis.MessageLevel.Info):
         """Log a message to QGIS."""
         QgsMessageLog.logMessage(message, "SamGeo", level)
 
@@ -1721,14 +1731,14 @@ class SamGeoPlugin:
                 if hasattr(sam_obj, "model") and sam_obj.model is not None:
                     try:
                         sam_obj.model.cpu()
-                    except Exception:
+                    except Exception:  # nosec B110
                         pass
                     try:
                         for param in sam_obj.model.parameters():
                             param.data = None
                             if param.grad is not None:
                                 param.grad = None
-                    except Exception:
+                    except Exception:  # nosec B110
                         pass
                     del sam_obj.model
                     sam_obj.model = None
@@ -1737,7 +1747,7 @@ class SamGeoPlugin:
                 for attr in list(vars(sam_obj).keys()):
                     try:
                         setattr(sam_obj, attr, None)
-                    except Exception:
+                    except Exception:  # nosec B110
                         # Ignore errors when clearing attributes; some may be read-only or protected.
                         pass
 
@@ -1758,7 +1768,7 @@ class SamGeoPlugin:
                 self.current_image_path = None
                 self.current_layer = None
 
-            except Exception:
+            except Exception:  # nosec B110
                 pass
 
         # Run garbage collection multiple times
@@ -1825,7 +1835,7 @@ class SamGeoPlugin:
 
         try:
             dialog = UpdateCheckerDialog(self.plugin_dir, self.iface.mainWindow())
-            dialog.exec_()
+            dialog.exec()
         except Exception as e:
             QMessageBox.critical(
                 self.iface.mainWindow(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,77 @@
+"""Shared pytest fixtures.
+
+Stubs the ``qgis`` package so the plugin's modules can be imported without a
+running QGIS instance. The stub reproduces the real ``qgis.PyQt`` shim
+behavior on Qt6: it re-exports ``QAction``, ``QActionGroup`` and ``QShortcut``
+from ``PyQt6.QtGui`` under ``qgis.PyQt.QtWidgets`` (they moved out of
+``QtWidgets`` in Qt6).
+"""
+
+import pathlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+import PyQt6.QtCore
+import PyQt6.QtGui
+import PyQt6.QtNetwork
+import PyQt6.QtWidgets
+
+
+def _install_qgis_stub() -> None:
+    qgis = types.ModuleType("qgis")
+    qgis.__path__ = []
+    sys.modules["qgis"] = qgis
+
+    qgis_pyqt = types.ModuleType("qgis.PyQt")
+    qgis_pyqt.__path__ = []
+    sys.modules["qgis.PyQt"] = qgis_pyqt
+    qgis.PyQt = qgis_pyqt
+
+    pyqt_submodules = {
+        "QtCore": PyQt6.QtCore,
+        "QtGui": PyQt6.QtGui,
+        "QtNetwork": PyQt6.QtNetwork,
+        "QtWidgets": PyQt6.QtWidgets,
+    }
+    for name, real in pyqt_submodules.items():
+        alias = types.ModuleType(f"qgis.PyQt.{name}")
+        for attr in dir(real):
+            if not attr.startswith("_"):
+                setattr(alias, attr, getattr(real, attr))
+        sys.modules[f"qgis.PyQt.{name}"] = alias
+        setattr(qgis_pyqt, name, alias)
+
+    # Qt6: QAction, QActionGroup, and QShortcut live in QtGui. The real
+    # qgis.PyQt.QtWidgets shim re-exports them, so mirror that here.
+    qtwidgets_alias = sys.modules["qgis.PyQt.QtWidgets"]
+    for attr in ("QAction", "QActionGroup", "QShortcut"):
+        setattr(qtwidgets_alias, attr, getattr(PyQt6.QtGui, attr))
+
+    for submodule in ("QtSvg", "QtWebEngineWidgets"):
+        alias = MagicMock()
+        sys.modules[f"qgis.PyQt.{submodule}"] = alias
+        setattr(qgis_pyqt, submodule, alias)
+
+    for name in ("core", "gui", "utils"):
+        stub = MagicMock()
+        stub.__spec__ = None
+        sys.modules[f"qgis.{name}"] = stub
+        setattr(qgis, name, stub)
+
+
+def _install_plugin_alias() -> None:
+    """Expose the repo root as the ``samgeo_plugin`` package.
+
+    QGIS loads this plugin under the directory name ``samgeo_plugin`` (see
+    ``install_plugin.sh``). The repo directory itself uses hyphens, which is
+    not a valid Python module name, so we register an explicit alias here.
+    """
+    repo_root = pathlib.Path(__file__).resolve().parent.parent
+    pkg = types.ModuleType("samgeo_plugin")
+    pkg.__path__ = [str(repo_root)]
+    sys.modules["samgeo_plugin"] = pkg
+
+
+_install_qgis_stub()
+_install_plugin_alias()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from ``PyQt6.QtGui`` under ``qgis.PyQt.QtWidgets`` (they moved out of
 ``QtWidgets`` in Qt6).
 """
 
+import importlib.util
 import pathlib
 import sys
 import types
@@ -61,16 +62,23 @@ def _install_qgis_stub() -> None:
 
 
 def _install_plugin_alias() -> None:
-    """Expose the repo root as the ``samgeo_plugin`` package.
+    """Load the repo's ``__init__.py`` as the ``samgeo_plugin`` package.
 
-    QGIS loads this plugin under the directory name ``samgeo_plugin`` (see
-    ``install_plugin.sh``). The repo directory itself uses hyphens, which is
-    not a valid Python module name, so we register an explicit alias here.
+    QGIS installs this plugin under the directory name ``samgeo_plugin`` (see
+    ``install_plugin.sh``); the repo directory itself uses hyphens, which is
+    not a valid Python module name. We use ``importlib.util`` to execute the
+    real ``__init__.py`` rather than registering a blank ``ModuleType`` alias,
+    so the smoke test also validates the package init under PyQt6.
     """
     repo_root = pathlib.Path(__file__).resolve().parent.parent
-    pkg = types.ModuleType("samgeo_plugin")
-    pkg.__path__ = [str(repo_root)]
-    sys.modules["samgeo_plugin"] = pkg
+    spec = importlib.util.spec_from_file_location(
+        "samgeo_plugin",
+        repo_root / "__init__.py",
+        submodule_search_locations=[str(repo_root)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["samgeo_plugin"] = module
+    spec.loader.exec_module(module)
 
 
 _install_qgis_stub()

--- a/tests/test_pyqt6_imports.py
+++ b/tests/test_pyqt6_imports.py
@@ -4,9 +4,10 @@ This catches short-form Qt enum regressions (for example ``Qt.AlignCenter``
 instead of ``Qt.AlignmentFlag.AlignCenter``) which raise ``AttributeError`` in
 PyQt6 during class-body evaluation.
 
-The plugin package is auto-discovered: the first sibling directory of
-``tests/`` that contains a ``metadata.txt`` is treated as the plugin root,
-so this file does not need to be edited per-plugin.
+The plugin package lives at the repo root (``metadata.txt`` sits next to
+``samgeo_plugin.py``), so ``PLUGIN_ROOT`` is set to the repo root and the
+package is exposed under the install-time name ``samgeo_plugin`` by
+``conftest.py``. Update both if the layout changes.
 """
 
 import importlib

--- a/tests/test_pyqt6_imports.py
+++ b/tests/test_pyqt6_imports.py
@@ -1,0 +1,53 @@
+"""Import-smoke tests that verify every plugin module loads under PyQt6.
+
+This catches short-form Qt enum regressions (for example ``Qt.AlignCenter``
+instead of ``Qt.AlignmentFlag.AlignCenter``) which raise ``AttributeError`` in
+PyQt6 during class-body evaluation.
+
+The plugin package is auto-discovered: the first sibling directory of
+``tests/`` that contains a ``metadata.txt`` is treated as the plugin root,
+so this file does not need to be edited per-plugin.
+"""
+
+import importlib
+import pathlib
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# This plugin's package lives at the repo root (metadata.txt sits next to
+# samgeo_plugin.py). When QGIS installs the plugin, the directory is named
+# ``samgeo_plugin`` (see install_plugin.sh); the conftest mirrors that name
+# in sys.modules so we use it as the dotted-import prefix here.
+PLUGIN_ROOT = REPO_ROOT
+PACKAGE_NAME = "samgeo_plugin"
+SKIP_DIRS = {"tests", ".git", "__pycache__", ".venv", "venv"}
+SKIP_MODULES = {
+    # test_plugin.py is the existing in-QGIS smoke script; it imports the
+    # real qgis.utils.iface and is not designed to run under the PyQt6 stub.
+    f"{PACKAGE_NAME}.test_plugin",
+    # install_plugin.py is a one-shot installer script invoked outside QGIS.
+    f"{PACKAGE_NAME}.install_plugin",
+}
+
+
+def _module_names():
+    """Yield dotted module names for every .py file under the plugin package."""
+    for path in sorted(PLUGIN_ROOT.rglob("*.py")):
+        if any(part in SKIP_DIRS for part in path.relative_to(PLUGIN_ROOT).parts):
+            continue
+        rel = path.relative_to(PLUGIN_ROOT).with_suffix("")
+        parts = (PACKAGE_NAME,) + rel.parts
+        if parts[-1] == "__init__":
+            parts = parts[:-1]
+        name = ".".join(parts)
+        if name in SKIP_MODULES:
+            continue
+        yield name
+
+
+@pytest.mark.parametrize("module_name", list(_module_names()))
+def test_module_imports_under_pyqt6(module_name):
+    """Each plugin module must import cleanly when qgis.PyQt maps to PyQt6."""
+    importlib.import_module(module_name)

--- a/update_checker.py
+++ b/update_checker.py
@@ -98,6 +98,10 @@ class VersionCheckWorker(QThread):
             self.error.emit(f"Error checking for updates: {str(e)}")
 
 
+class _DownloadCanceled(Exception):
+    """Raised inside DownloadWorker.run when the user cancels the download."""
+
+
 class DownloadWorker(QThread):
     """Worker thread for downloading and installing the plugin update."""
 
@@ -109,9 +113,17 @@ class DownloadWorker(QThread):
         super().__init__()
         self.plugin_dir = plugin_dir
 
+    def _check_canceled(self):
+        """Raise ``_DownloadCanceled`` if cooperative cancel was requested."""
+        if self.isInterruptionRequested():
+            raise _DownloadCanceled()
+
     def run(self):
         """Download and install the latest plugin version."""
         temp_dir = None
+        target_dir = None
+        backup_dir = None
+        moved_to_backup = False
         try:
             # Create temporary directory
             temp_dir = tempfile.mkdtemp(prefix="samgeo_update_")
@@ -121,6 +133,8 @@ class DownloadWorker(QThread):
             self.progress.emit(10, "Downloading plugin from GitHub...")
 
             def reporthook(block_num, block_size, total_size):
+                # Cooperative cancel: aborts urlretrieve from inside its callback.
+                self._check_canceled()
                 if total_size > 0:
                     downloaded = block_num * block_size
                     percent = min(int((downloaded / total_size) * 50), 50)
@@ -128,6 +142,7 @@ class DownloadWorker(QThread):
 
             urlretrieve(_require_https(ZIP_URL), zip_path, reporthook)  # nosec B310
 
+            self._check_canceled()
             self.progress.emit(60, "Extracting files...")
 
             # Extract the zip file
@@ -143,6 +158,7 @@ class DownloadWorker(QThread):
                         )
                 zip_ref.extractall(extract_dir)
 
+            self._check_canceled()
             self.progress.emit(70, "Locating plugin files...")
 
             # Find the plugin directory in the extracted files
@@ -157,6 +173,7 @@ class DownloadWorker(QThread):
                 self.error.emit("Could not find plugin files in downloaded archive")
                 return
 
+            self._check_canceled()
             self.progress.emit(80, "Installing update...")
 
             # Get the parent directory of the current plugin (QGIS plugins folder)
@@ -167,9 +184,14 @@ class DownloadWorker(QThread):
             # Backup current plugin (optional - we'll just replace)
             backup_dir = os.path.join(temp_dir, "backup")
 
+            # Last cancel checkpoint before we touch the live install. Past this
+            # point the finally block is responsible for restoring the backup.
+            self._check_canceled()
+
             # If target exists, move it to backup
             if os.path.exists(target_dir):
                 shutil.move(target_dir, backup_dir)
+                moved_to_backup = True
 
             try:
                 # Copy new plugin files
@@ -188,6 +210,7 @@ class DownloadWorker(QThread):
                     if os.path.exists(target_dir):
                         shutil.rmtree(target_dir)
                     shutil.move(backup_dir, target_dir)
+                    moved_to_backup = False
                 else:
                     # Backup is missing or invalid, cannot restore
                     self.error.emit(
@@ -195,6 +218,8 @@ class DownloadWorker(QThread):
                     )
                 raise e
 
+        except _DownloadCanceled:
+            self.error.emit("Update canceled.")
         except HTTPError as e:
             self.error.emit(f"HTTP Error downloading: {e.code} - {e.reason}")
         except URLError as e:
@@ -202,6 +227,20 @@ class DownloadWorker(QThread):
         except Exception as e:
             self.error.emit(f"Error installing update: {str(e)}")
         finally:
+            # If we moved the live plugin into the backup but never copied the
+            # new files into place, restore it before nuking the temp dir.
+            if (
+                moved_to_backup
+                and target_dir
+                and backup_dir
+                and not os.path.exists(target_dir)
+                and os.path.isdir(backup_dir)
+            ):
+                try:
+                    shutil.move(backup_dir, target_dir)
+                except OSError:
+                    pass
+
             # Cleanup temp directory
             if temp_dir and os.path.exists(temp_dir):
                 try:
@@ -508,7 +547,14 @@ class UpdateCheckerDialog(QDialog):
             if reply != QMessageBox.StandardButton.Yes:
                 event.ignore()
                 return
-            self.download_worker.terminate()
-            self.download_worker.wait()
+            # Cooperative cancel: the worker checks isInterruptionRequested at
+            # safe points and restores the backup before its finally cleanup,
+            # so we avoid bricking the install via a hard terminate.
+            self.download_worker.requestInterruption()
+            if not self.download_worker.wait(10000):
+                # Last-resort hard kill if the worker is wedged. The worker's
+                # finally still tries to restore from backup on next start.
+                self.download_worker.terminate()
+                self.download_worker.wait()
 
         event.accept()

--- a/update_checker.py
+++ b/update_checker.py
@@ -37,6 +37,23 @@ METADATA_URL = (
 ZIP_URL = f"https://github.com/{GITHUB_REPO}/archive/refs/heads/{GITHUB_BRANCH}.zip"
 
 
+def _require_https(url):
+    """Raise ValueError unless the URL uses the https scheme.
+
+    Args:
+        url: The URL to validate.
+
+    Returns:
+        str: The same URL, unchanged.
+
+    Raises:
+        ValueError: If the URL does not start with ``https://``.
+    """
+    if not url.startswith("https://"):
+        raise ValueError(f"Refusing to open non-https URL: {url}")
+    return url
+
+
 class VersionCheckWorker(QThread):
     """Worker thread for checking the latest version from GitHub."""
 
@@ -46,7 +63,9 @@ class VersionCheckWorker(QThread):
     def run(self):
         """Fetch the latest metadata from GitHub."""
         try:
-            with urlopen(METADATA_URL, timeout=15) as response:
+            with urlopen(
+                _require_https(METADATA_URL), timeout=15
+            ) as response:  # nosec B310
                 content = response.read().decode("utf-8")
 
             # Parse version from metadata
@@ -107,7 +126,7 @@ class DownloadWorker(QThread):
                     percent = min(int((downloaded / total_size) * 50), 50)
                     self.progress.emit(10 + percent, "Downloading...")
 
-            urlretrieve(ZIP_URL, zip_path, reporthook)
+            urlretrieve(_require_https(ZIP_URL), zip_path, reporthook)  # nosec B310
 
             self.progress.emit(60, "Extracting files...")
 
@@ -233,7 +252,7 @@ class UpdateCheckerDialog(QDialog):
         header_font.setPointSize(14)
         header_font.setBold(True)
         header_label.setFont(header_font)
-        header_label.setAlignment(Qt.AlignCenter)
+        header_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(header_label)
 
         # Version info group
@@ -278,7 +297,7 @@ class UpdateCheckerDialog(QDialog):
         # Progress label
         self.progress_label = QLabel("")
         self.progress_label.setVisible(False)
-        self.progress_label.setAlignment(Qt.AlignCenter)
+        self.progress_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self.progress_label)
 
         # Buttons
@@ -307,7 +326,7 @@ class UpdateCheckerDialog(QDialog):
         )
         info_label.setWordWrap(True)
         info_label.setOpenExternalLinks(True)
-        info_label.setAlignment(Qt.AlignCenter)
+        info_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(info_label)
 
     def check_for_updates(self):
@@ -398,11 +417,11 @@ class UpdateCheckerDialog(QDialog):
             f"This will download and install version {self.latest_version}.\n\n"
             "IMPORTANT: You will need to restart QGIS after the update completes.\n\n"
             "Do you want to continue?",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
 
-        if reply != QMessageBox.Yes:
+        if reply != QMessageBox.StandardButton.Yes:
             return
 
         self.check_btn.setEnabled(False)
@@ -483,10 +502,10 @@ class UpdateCheckerDialog(QDialog):
                 self,
                 "Download in Progress",
                 "A download is in progress. Are you sure you want to cancel?",
-                QMessageBox.Yes | QMessageBox.No,
-                QMessageBox.No,
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
             )
-            if reply != QMessageBox.Yes:
+            if reply != QMessageBox.StandardButton.Yes:
                 event.ignore()
                 return
             self.download_worker.terminate()


### PR DESCRIPTION
## Summary

- Make the plugin load cleanly on **both** QGIS 3.22+ (PyQt5) and QGIS 4.0 (PyQt6) from a single codebase. Fully-qualified enums (`Qt.AlignmentFlag.AlignCenter`, etc.) are accepted by both.
- Set `qgisMaximumVersion=4.99` in `metadata.txt` so the plugin lands on the [QGIS 4 Ready list](https://plugins.qgis.org/plugins/new_qgis_ready/). Bump `version=1.4.0`.
- Resolve every finding from the Bandit security scan that `plugins.qgis.org` runs on every upload (currently 2 medium + 35 low) — `urlopen`/`urlretrieve` get an https-only guard, intentional `subprocess` and `try/except/pass` sites are explicitly annotated with `# nosec <id>`.
- Add PyQt6 import-smoke tests, a CI workflow (pre-commit / bandit / PyQt6 imports across Python 3.10-3.13), and a Bandit pre-commit hook so contributors catch issues before push.

References:
- https://github.com/qgis/QGIS/wiki/Plugin-migration-to-be-compatible-with-Qt5-and-Qt6
- https://plugins.qgis.org/docs/migrate-qgis4

## What changed

| Area | Change |
| --- | --- |
| `metadata.txt` | `qgisMaximumVersion=4.99`, `version=1.4.0`, changelog entry. |
| Qt enums | `Qt.AlignCenter` -> `Qt.AlignmentFlag.AlignCenter`, `Qt.LeftDockWidgetArea/RightDockWidgetArea` -> `Qt.DockWidgetArea.*`, `Qt.LeftButton/RightButton` -> `Qt.MouseButton.*`, `Qt.CrossCursor` -> `Qt.CursorShape.CrossCursor`, `Qt.green/red` -> `Qt.GlobalColor.*`. |
| `QMessageBox` | `QMessageBox.Yes/No` -> `QMessageBox.StandardButton.Yes/No`. |
| QGIS core enums | `Qgis.Info/Warning/Critical/Success` -> `Qgis.MessageLevel.*`; `QgsWkbTypes.PolygonGeometry/PointGeometry` -> `QgsWkbTypes.GeometryType.*`. |
| `exec_()` | Replaced with `exec()`. |
| Bandit | `_require_https()` guard for `urlopen`/`urlretrieve` (B310); explicit `# nosec` annotations on intentional `subprocess.run/Popen` (B404/B603/B607) and `try/except/pass` (B110) sites. `bandit -r . -x ./tests` is now clean. |
| Tests | New `tests/` with `conftest.py` (qgis.PyQt PyQt6 stub) and `test_pyqt6_imports.py` parametrized over every plugin module. |
| CI | New `.github/workflows/ci.yml` with `pre-commit`, `bandit`, and `pyqt6-smoke` (Python 3.10/3.11/3.12/3.13) jobs. |
| pre-commit | Added Bandit hook so the same scan runs locally. |

`supportsQt6=True` is intentionally **not** added — that flag was removed from QGIS 4.0 core; only the version range matters.

## Test plan

Automated:

- [x] `python -m compileall .` clean.
- [x] `bandit -r . -x ./tests` reports `No issues identified.`
- [x] `pytest tests/ -v` — 13 PyQt6 import-smoke tests pass.
- [x] `pre-commit run --all-files` clean (now includes Bandit).

Manual (please verify before merging — the import-smoke test proves modules load, not that the UI works):

- [ ] Install branch into QGIS 3.28+ (PyQt5): toolbar, dock placement, dependency installer dialog, update-checker dialog (`exec()` path), `QMessageBox` confirmations, point/box prompt tools.
- [ ] Install branch into a QGIS 4.0 nightly (PyQt6): repeat the same checks; pay attention to dock area placement and `QMessageBox` button identification.