### PR TITLE
Add QGIS plugin publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: Publish
+
+on:
+    release:
+        types: [published]
+    workflow_dispatch:
+        inputs:
+            tag:
+                description: "Release tag to publish (must already exist on GitHub)"
+                required: true
+                type: string
+
+permissions:
+    contents: write
+
+jobs:
+    publish:
+        name: Publish plugin to plugins.qgis.org
+        runs-on: ubuntu-latest
+        env:
+            TAG: ${{ github.event.release.tag_name || inputs.tag }}
+            PLUGIN_DIR: .
+            PLUGIN_NAME: samgeo_plugin
+            ZIP_PATH: dist/samgeo_plugin.zip
+        steps:
+            - uses: actions/checkout@v6
+
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: "3.13"
+
+            - name: Build plugin zip
+              run: python "package_plugin.py" --source "$PLUGIN_DIR" --name "$PLUGIN_NAME" --output "$ZIP_PATH"
+
+            - name: Verify metadata version matches release tag
+              run: |
+                  metadata_version=$(grep '^version=' "$PLUGIN_DIR/metadata.txt" | cut -d'=' -f2 | tr -d '[:space:]')
+                  tag_version="${TAG#v}"
+                  if [ "$metadata_version" != "$tag_version" ]; then
+                      echo "::error::metadata.txt version ($metadata_version) does not match release tag ($tag_version)"
+                      exit 1
+                  fi
+
+            - name: Attach zip to GitHub release
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  gh release upload "$TAG" "$ZIP_PATH" --clobber
+
+            - name: Upload to plugins.qgis.org
+              env:
+                  QGIS_PLUGIN_REPO_USERNAME: ${{ secrets.QGIS_PLUGIN_REPO_USERNAME }}
+                  QGIS_PLUGIN_REPO_PASSWORD: ${{ secrets.QGIS_PLUGIN_REPO_PASSWORD }}
+              run: python scripts/upload_to_qgis_plugin_repo.py "$ZIP_PATH"

--- a/package_plugin.py
+++ b/package_plugin.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Package a QGIS plugin directory for upload to the official QGIS plugin repository."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import zipfile
+from pathlib import Path
+
+EXCLUDE_PATTERNS = [
+    r"^ui_.*\.py$",
+    r"^resources_rc\.py$",
+    r"^.*_rc\.py$",
+    r"^.*\.pyc$",
+    r"^.*\.pyo$",
+    r"^.*\.bak$",
+    r"^.*~$",
+    r"^\..*\.swp$",
+    r"^.*\.orig$",
+    r"^package_plugin\.py$",
+]
+
+EXCLUDE_DIRS = {
+    "__pycache__",
+    "__MACOSX",
+    ".git",
+    ".svn",
+    ".hg",
+    ".github",
+    ".idea",
+    ".vscode",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".tox",
+    ".eggs",
+    "build",
+    "dist",
+    "node_modules",
+    "scripts",
+    "help",
+}
+
+
+def should_exclude_file(filename: str) -> bool:
+    return any(re.match(pattern, filename) for pattern in EXCLUDE_PATTERNS)
+
+
+def should_exclude_dir(dirname: str) -> bool:
+    return dirname.startswith(".") or dirname in EXCLUDE_DIRS or dirname.endswith(".egg-info")
+
+
+def get_version_from_metadata(plugin_dir: Path) -> str:
+    metadata_file = plugin_dir / "metadata.txt"
+    if metadata_file.exists():
+        with metadata_file.open("r", encoding="utf-8") as f:
+            for line in f:
+                if line.startswith("version="):
+                    return line.split("=", 1)[1].strip()
+    return "unknown"
+
+
+def package_plugin(source_dir: Path, output_path: Path | None, target_name: str) -> Path:
+    if not source_dir.exists():
+        raise FileNotFoundError(f"Source directory not found: {source_dir}")
+    if not source_dir.is_dir():
+        raise ValueError(f"Source path is not a directory: {source_dir}")
+
+    version = get_version_from_metadata(source_dir)
+    if output_path is None:
+        output_path = source_dir.parent / f"{target_name}-{version}.zip"
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if output_path.exists():
+        output_path.unlink()
+
+    print(f"Packaging plugin from: {source_dir}")
+    print(f"Output zip file: {output_path}")
+    print(f"Root folder name in zip: {target_name}")
+    print(f"Plugin version: {version}")
+
+    files_added = 0
+    files_excluded = 0
+    with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zipf:
+        for root, dirs, files in os.walk(source_dir):
+            dirs[:] = [d for d in dirs if not should_exclude_dir(d)]
+            for file in files:
+                file_path = Path(root) / file
+                if should_exclude_file(file) or file.startswith("."):
+                    files_excluded += 1
+                    continue
+                rel_path = file_path.relative_to(source_dir)
+                archive_name = Path(target_name) / rel_path
+                zipf.write(file_path, archive_name)
+                files_added += 1
+
+    print(f"Package created successfully: {output_path}")
+    print(f"Files added: {files_added}")
+    print(f"Files excluded: {files_excluded}")
+    return output_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", "-o", type=Path, default=None, help="Output path for the zip file")
+    parser.add_argument("--source", "-s", type=Path, default=Path("."), help="Source plugin directory")
+    parser.add_argument("--name", "-n", default=None, help="Target plugin folder name in the zip")
+    args = parser.parse_args()
+
+    source_dir = args.source.resolve()
+    target_name = args.name or source_dir.name
+    package_plugin(source_dir, args.output, target_name)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/package_plugin.py
+++ b/package_plugin.py
@@ -48,7 +48,11 @@ def should_exclude_file(filename: str) -> bool:
 
 
 def should_exclude_dir(dirname: str) -> bool:
-    return dirname.startswith(".") or dirname in EXCLUDE_DIRS or dirname.endswith(".egg-info")
+    return (
+        dirname.startswith(".")
+        or dirname in EXCLUDE_DIRS
+        or dirname.endswith(".egg-info")
+    )
 
 
 def get_version_from_metadata(plugin_dir: Path) -> str:
@@ -61,7 +65,9 @@ def get_version_from_metadata(plugin_dir: Path) -> str:
     return "unknown"
 
 
-def package_plugin(source_dir: Path, output_path: Path | None, target_name: str) -> Path:
+def package_plugin(
+    source_dir: Path, output_path: Path | None, target_name: str
+) -> Path:
     if not source_dir.exists():
         raise FileNotFoundError(f"Source directory not found: {source_dir}")
     if not source_dir.is_dir():
@@ -103,9 +109,15 @@ def package_plugin(source_dir: Path, output_path: Path | None, target_name: str)
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--output", "-o", type=Path, default=None, help="Output path for the zip file")
-    parser.add_argument("--source", "-s", type=Path, default=Path("."), help="Source plugin directory")
-    parser.add_argument("--name", "-n", default=None, help="Target plugin folder name in the zip")
+    parser.add_argument(
+        "--output", "-o", type=Path, default=None, help="Output path for the zip file"
+    )
+    parser.add_argument(
+        "--source", "-s", type=Path, default=Path("."), help="Source plugin directory"
+    )
+    parser.add_argument(
+        "--name", "-n", default=None, help="Target plugin folder name in the zip"
+    )
     args = parser.parse_args()
 
     source_dir = args.source.resolve()

--- a/scripts/upload_to_qgis_plugin_repo.py
+++ b/scripts/upload_to_qgis_plugin_repo.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Upload a packaged QGIS plugin zip to plugins.qgis.org via XML-RPC.
+
+The official plugin repository exposes an XML-RPC endpoint at
+``https://plugins.qgis.org/plugins/RPC2/`` with a ``plugin.upload`` method
+that accepts the zipped plugin as a base64-encoded ``Binary`` payload and
+returns the new plugin id and version id on success.
+
+Credentials must belong to a user with upload rights for the plugin and are
+read from the ``QGIS_PLUGIN_REPO_USERNAME`` and ``QGIS_PLUGIN_REPO_PASSWORD``
+environment variables so this script can be used from CI without leaking
+secrets onto the command line.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from urllib.parse import quote
+from xmlrpc.client import Binary, Fault, ProtocolError, ServerProxy
+
+REPO_URL_TEMPLATE = "https://{user}:{password}@plugins.qgis.org/plugins/RPC2/"
+
+
+def upload(zip_path: str, username: str, password: str) -> tuple[int, int]:
+    """Upload the given zip to plugins.qgis.org and return ``(plugin_id, version_id)``."""
+    with open(zip_path, "rb") as fh:
+        payload = Binary(fh.read())
+
+    endpoint = REPO_URL_TEMPLATE.format(
+        user=quote(username, safe=""),
+        password=quote(password, safe=""),
+    )
+    server = ServerProxy(endpoint, verbose=False)
+    plugin_id, version_id = server.plugin.upload(payload)
+    return plugin_id, version_id
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("zip_path", help="Path to the packaged plugin zip")
+    args = parser.parse_args()
+
+    username = os.environ.get("QGIS_PLUGIN_REPO_USERNAME")
+    password = os.environ.get("QGIS_PLUGIN_REPO_PASSWORD")
+    if not username or not password:
+        print(
+            "Error: QGIS_PLUGIN_REPO_USERNAME and QGIS_PLUGIN_REPO_PASSWORD must be set.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not os.path.isfile(args.zip_path):
+        print(f"Error: zip file not found: {args.zip_path}", file=sys.stderr)
+        return 1
+
+    try:
+        plugin_id, version_id = upload(args.zip_path, username, password)
+    except Fault as exc:
+        print(
+            f"Upload failed: {exc.faultString} (code {exc.faultCode})", file=sys.stderr
+        )
+        return 1
+    except ProtocolError as exc:
+        print(f"Upload failed: HTTP {exc.errcode} {exc.errmsg}", file=sys.stderr)
+        return 1
+
+    print(f"Uploaded plugin id={plugin_id}, version id={version_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add a release/workflow_dispatch publish workflow for QGIS plugin releases.
- Build the plugin zip, verify the metadata version matches the release tag, attach the zip to the GitHub release, and upload it to plugins.qgis.org.
- Add the shared plugins.qgis.org XML-RPC upload helper.

## Validation
- Ran the local package command used by the workflow.
- Verified the generated zip contains `metadata.txt` and `__init__.py` under the expected plugin root.
