### PR TITLE
Fix QGIS plugin reload cleanup

### DIFF
--- a/samgeo_plugin.py
+++ b/samgeo_plugin.py
@@ -41,9 +41,9 @@ from qgis.core import (
 # Import the map tools
 from .map_tools import PointPromptTool, BoxPromptTool
 
-
 TOOLBAR_OBJECT_NAME = "SamGeo"
 MENU_TITLE = "&SamGeo"
+
 
 class SamGeoPlugin:
     """QGIS Plugin for remote sensing image segmentation using SamGeo."""
@@ -176,7 +176,6 @@ class SamGeoPlugin:
             status_tip=self.tr("About SamGeo Plugin"),
             add_to_toolbar=False,
         )
-
 
     def _remove_toolbar(self, toolbar):
         """Detach and schedule deletion of a plugin toolbar widget."""

--- a/samgeo_plugin.py
+++ b/samgeo_plugin.py
@@ -8,6 +8,7 @@ from qgis.PyQt.QtCore import Qt, QCoreApplication
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import (
     QAction,
+    QToolBar,
     QDockWidget,
     QWidget,
     QVBoxLayout,
@@ -41,6 +42,9 @@ from qgis.core import (
 from .map_tools import PointPromptTool, BoxPromptTool
 
 
+TOOLBAR_OBJECT_NAME = "SamGeo"
+MENU_TITLE = "&SamGeo"
+
 class SamGeoPlugin:
     """QGIS Plugin for remote sensing image segmentation using SamGeo."""
 
@@ -57,8 +61,10 @@ class SamGeoPlugin:
         # Initialize plugin attributes
         self.actions = []
         self.menu = "&SamGeo"
+        self._remove_toolbars_by_object_name()
+        self._remove_menus_by_title()
         self.toolbar = self.iface.addToolBar("SamGeo")
-        self.toolbar.setObjectName("SamGeo")
+        self.toolbar.setObjectName(TOOLBAR_OBJECT_NAME)
 
         # Dock widget
         self.dock_widget = None
@@ -171,6 +177,93 @@ class SamGeoPlugin:
             add_to_toolbar=False,
         )
 
+
+    def _remove_toolbar(self, toolbar):
+        """Detach and schedule deletion of a plugin toolbar widget."""
+        if toolbar is None:
+            return
+
+        main_window = self.iface.mainWindow()
+        actions = []
+        try:
+            actions = list(toolbar.actions())
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.clear()
+        except Exception:
+            pass  # nosec B110
+        for action in actions:
+            try:
+                action.deleteLater()
+            except Exception:
+                pass  # nosec B110
+        try:
+            main_window.removeToolBar(toolbar)
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.hide()
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.setParent(None)
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.deleteLater()
+        except Exception:
+            pass  # nosec B110
+
+    def _remove_toolbars_by_object_name(self):
+        """Remove current or stale plugin toolbars from QGIS."""
+        main_window = self.iface.mainWindow()
+        for toolbar in main_window.findChildren(QToolBar, TOOLBAR_OBJECT_NAME):
+            self._remove_toolbar(toolbar)
+
+    def _plugin_menu_titles(self):
+        """Return possible translated and untranslated plugin menu titles."""
+        titles = {MENU_TITLE}
+        translator = getattr(self, "tr", None)
+        if callable(translator):
+            try:
+                titles.add(translator(MENU_TITLE))
+            except Exception:
+                pass  # nosec B110
+        return titles
+
+    def _remove_menu(self, menu):
+        """Detach and schedule deletion of a plugin menu."""
+        if menu is None:
+            return
+
+        main_window = self.iface.mainWindow()
+        try:
+            menu.clear()
+        except Exception:
+            pass  # nosec B110
+        try:
+            main_window.menuBar().removeAction(menu.menuAction())
+        except Exception:
+            pass  # nosec B110
+        try:
+            menu.setParent(None)
+        except Exception:
+            pass  # nosec B110
+        try:
+            menu.deleteLater()
+        except Exception:
+            pass  # nosec B110
+
+    def _remove_menus_by_title(self):
+        """Remove current or stale plugin menus from QGIS."""
+        menu_bar = self.iface.mainWindow().menuBar()
+        titles = self._plugin_menu_titles()
+        for action in menu_bar.actions():
+            menu = action.menu()
+            if menu is not None and menu.title() in titles:
+                self._remove_menu(menu)
+
     def unload(self):
         """Remove the plugin menu item and icon from QGIS GUI."""
         for action in self.actions:
@@ -200,6 +293,9 @@ class SamGeoPlugin:
         if self.sam is not None:
             del self.sam
             self.sam = None
+
+        self._remove_toolbars_by_object_name()
+        self._remove_menus_by_title()
 
     # ------------------------------------------------------------------
     # Dependency management


### PR DESCRIPTION
## Summary

Fix QGIS Plugin Reloader warnings caused by custom plugin toolbars and menus that can remain attached to the QGIS main window after `unload()`.

## Changes

- Remove stale plugin toolbars by object name before creating a new toolbar.
- Detach and schedule stale toolbars for deletion during unload.
- Remove stale plugin menus by title before initialization and during unload.
- Keep cleanup best-effort so reload/unload can continue even if QGIS has already detached a widget.

## Validation

- Ran `python -m py_compile` on the changed plugin entry-point file.
- Ran `git diff --check`.
